### PR TITLE
Mobile nav transition

### DIFF
--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -40,12 +40,18 @@
 			</button>
 		</nav>
 
-		{#if navOpen}
-			<ul class="flex flex-col gap-6 px-8 pb-6 text-lg font-medium md:hidden">
-				<li><a on:click={() => (navOpen = false)} href="/blog">Blog</a></li>
-				<li><a on:click={() => (navOpen = false)} href="/about">About</a></li>
+		<!-- Mobile menu with slide animation -->
+		<div
+			class="grid transition-all duration-300 ease-in-out md:hidden"
+			style="grid-template-rows: {navOpen ? '1fr' : '0fr'}"
+		>
+			<ul class="overflow-hidden">
+				<div class="flex flex-col gap-6 px-8 pb-6 text-lg font-medium">
+					<li><a on:click={() => (navOpen = false)} href="/blog">Blog</a></li>
+					<li><a on:click={() => (navOpen = false)} href="/about">About</a></li>
+				</div>
 			</ul>
-		{/if}
+		</div>
 	</header>
 
 	<slot />


### PR DESCRIPTION
### TL;DR

Added a smooth slide animation to the mobile navigation menu.

### What changed?

- Replaced the conditional rendering of the mobile menu with a grid-based animation approach
- Wrapped the navigation links in an additional div for proper styling
- Added transition properties (duration, easing) to create a smooth slide effect
- Used CSS grid template rows that dynamically adjust based on the menu state
- Added an overflow-hidden property to contain the animation

### How to test?

1. View the site on a mobile device or using responsive mode in browser dev tools
2. Click the navigation toggle button to open and close the menu
3. Verify that the menu now slides open/closed with a smooth animation instead of abruptly appearing/disappearing
4. Confirm that menu links still work correctly and close the menu when clicked

### Why make this change?

The previous implementation toggled the mobile menu visibility with a simple conditional render, causing it to appear and disappear abruptly. This change improves the user experience by adding a smooth animation that makes the navigation feel more polished and professional.